### PR TITLE
Add ImGui to CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,10 +7,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 
-# TODO - Fetch ImGui
+# Include FetchContent Module
 include(FetchContent)
 
-# Fetch ImGui and make availble
+# Fetch ImGui
 FetchContent_Declare(
     imgui
     GIT_REPOSITORY https://github.com/ocornut/imgui
@@ -18,10 +18,8 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(imgui)
 
-# Set ImGui_dir
+# Include imgui source Files
 set(IMGUI_DIR ${CMAKE_BINARY_DIR}/_deps/imgui-src)
-
-# ImGui source files
 set(IMGUI_SOURCES
     ${IMGUI_DIR}/imgui.cpp
     ${IMGUI_DIR}/imgui_draw.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,28 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 # TODO - Fetch ImGui
 include(FetchContent)
 
+# Fetch ImGui and make availble
+FetchContent_Declare(
+    imgui
+    GIT_REPOSITORY https://github.com/ocornut/imgui
+    GIT_TAG v1.91.8-docking
+)
+FetchContent_MakeAvailable(imgui)
+
+# Set ImGui_dir
+set(IMGUI_DIR ${CMAKE_BINARY_DIR}/_deps/imgui-src)
+
+# ImGui source files
+set(IMGUI_SOURCES
+    ${IMGUI_DIR}/imgui.cpp
+    ${IMGUI_DIR}/imgui_draw.cpp
+    ${IMGUI_DIR}/imgui_demo.cpp
+    ${IMGUI_DIR}/imgui_widgets.cpp
+    ${IMGUI_DIR}/imgui_tables.cpp
+    ${IMGUI_DIR}/backends/imgui_impl_glfw.cpp
+    ${IMGUI_DIR}/backends/imgui_impl_opengl3.cpp
+)
+
 # TODO - Find package openGL
 
 # Executable

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,11 @@ set(IMGUI_SOURCES
     ${IMGUI_DIR}/backends/imgui_impl_opengl3.cpp
 )
 
+# Create imgui library
+add_library(imgui STATIC ${IMGUI_SOURCES})
+target_include_directories(imgui PUBLIC ${IMGUI_DIR} ${IMGUI_DIR}/backends)
+target_link_libraries(imgui PUBLIC glfw)
+
 # TODO - Find package openGL
 
 # Executable
@@ -42,3 +47,4 @@ add_subdirectory(include)
 add_subdirectory(src)
 target_link_libraries(${PROJECT_NAME} include)
 target_link_libraries(${PROJECT_NAME} src)
+target_link_libraries(${PROJECT_NAME} imgui)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,11 +12,16 @@ include(FetchContent)
 
 # Fetch ImGui
 FetchContent_Declare(
+    glfw
+    GIT_REPOSITORY https://github.com/glfw/glfw.git
+    GIT_TAG latest
+)
+FetchContent_Declare(
     imgui
     GIT_REPOSITORY https://github.com/ocornut/imgui
     GIT_TAG v1.91.8-docking
 )
-FetchContent_MakeAvailable(imgui)
+FetchContent_MakeAvailable(imgui glfw)
 
 # Include imgui source Files
 set(IMGUI_DIR ${CMAKE_BINARY_DIR}/_deps/imgui-src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+
 # TODO - Fetch ImGui
+include(FetchContent)
 
 # TODO - Find package openGL
 


### PR DESCRIPTION
Add ImGui to CMake build with the glfw backend (cross platform and simple)