### PR TITLE
Render distance

### DIFF
--- a/include/Window.h
+++ b/include/Window.h
@@ -2,7 +2,6 @@
 #define WINDOW_H
 
 #include <vector>
-#include <cmath>
 
 #include "raylib.h"
 

--- a/include/Window.h
+++ b/include/Window.h
@@ -2,6 +2,7 @@
 #define WINDOW_H
 
 #include <vector>
+#include <cmath>
 
 #include "raylib.h"
 
@@ -30,6 +31,7 @@ private:
 private:
   const std::vector<CelestialBody>& SolarSystem;
   std::vector<float> rotation;
+  float modelScale;
 
 private:
   const float focalScale = 1;

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -29,7 +29,8 @@
 
 Window::Window(const std::vector<CelestialBody>& SolarSystem)
   : SolarSystem(SolarSystem),
-    focalSize(static_cast<float>(SolarSystem.crbegin()->getOrbitRadius() * focalScale))
+    modelScale(100/SolarSystem.crbegin()->getRadius()),
+    focalSize(static_cast<float>(SolarSystem.crbegin()->getOrbitRadius() * focalScale / modelScale))
 {
   InitWindow(1600, 1000, "Solar System");
   LoadStars();
@@ -126,8 +127,8 @@ void Window::Update()
       int i = 0;
       for (const auto iter : SolarSystem)
       {
-        const float scaledOrbitRadius = static_cast<float>(iter.getOrbitRadius());
-        const float scaledRadius = static_cast<float>(iter.getRadius());
+        const float scaledOrbitRadius = static_cast<float>(iter.getOrbitRadius()) / modelScale;
+        const float scaledRadius = static_cast<float>(iter.getRadius()) / modelScale;
 
         rlPushMatrix();
 


### PR DESCRIPTION
Using raylib there is no way to change render distance, its hard coded with a preprocessor directive [here](https://github.com/raysan5/raylib/blob/master/src/rcamera.h#L69). 

So instead I created a model scale member of the window based on making the furthest body in the solar system 100 units away.